### PR TITLE
feat:H105-L2 : Auth Capture and Void for Bambora

### DIFF
--- a/config/Development.toml
+++ b/config/Development.toml
@@ -11,8 +11,8 @@ enabled = false
 
 # TODO: Update database credentials before running application
 [master_database]
-username = "db_user"
-password = "db_pass"
+username = "hyperswitch_app"
+password = "admin"
 host = "localhost"
 port = 5432
 dbname = "hyperswitch_db"
@@ -43,7 +43,7 @@ locker_decryption_key2 = ""
 
 [connectors.supported]
 wallets = ["klarna","braintree","applepay"]
-cards = ["stripe","adyen","authorizedotnet","checkout","braintree","aci","shift4","cybersource", "worldpay", "globalpay", "fiserv", "payu", "worldline"]
+cards = ["stripe","adyen","authorizedotnet","checkout","braintree","aci","shift4","cybersource", "worldpay", "globalpay", "fiserv", "payu", "worldline", "bambora"]
 
 [refund]
 max_attempts = 10
@@ -102,6 +102,9 @@ base_url = "https://apis.sandbox.globalpay.com/ucp/"
 
 [connectors.worldline]
 base_url = "https://eu.sandbox.api-ingenico.com/"
+
+[connectors.bambora]
+base_url = "https://api.na.bambora.com/"
 
 [scheduler]
 stream = "SCHEDULER_STREAM"

--- a/config/Development.toml
+++ b/config/Development.toml
@@ -11,8 +11,8 @@ enabled = false
 
 # TODO: Update database credentials before running application
 [master_database]
-username = "hyperswitch_app"
-password = "admin"
+username = "db_user"
+password = "db_pass"
 host = "localhost"
 port = 5432
 dbname = "hyperswitch_db"

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -152,6 +152,9 @@ base_url = "https://try.access.worldpay.com/"
 base_url = "https://apis.sandbox.globalpay.com/ucp/"
 
 # This data is used to call respective connectors for wallets and cards
+[connectors.bambora]
+base_url = "https://api.na.bambora.com/"
+
 [connectors.supported]
 wallets = ["klarna", "braintree", "applepay"]
 cards = [
@@ -164,6 +167,7 @@ cards = [
     "shift4",
     "worldpay",
     "globalpay",
+    "bambora"
 ]
 
 # Scheduler settings provides a point to modify the behaviour of scheduler flow.

--- a/config/docker_compose.toml
+++ b/config/docker_compose.toml
@@ -105,9 +105,12 @@ base_url = "https://try.access.worldpay.com/"
 [connectors.globalpay]
 base_url = "https://apis.sandbox.globalpay.com/ucp/"
 
+[connectors.bambora]
+base_url = "https://api.na.bambora.com/"
+
 [connectors.supported]
 wallets = ["klarna", "braintree", "applepay"]
-cards = ["stripe", "adyen", "authorizedotnet", "checkout", "braintree", "shift4", "cybersource", "worldpay", "globalpay", "fiserv"]
+cards = ["stripe", "adyen", "authorizedotnet", "checkout", "braintree", "shift4", "cybersource", "worldpay", "globalpay", "fiserv", "bambora"]
 
 
 [scheduler]

--- a/crates/api_models/src/enums.rs
+++ b/crates/api_models/src/enums.rs
@@ -519,6 +519,7 @@ pub enum Connector {
     Cybersource,
     #[default]
     Dummy,
+	Bambora,
     Fiserv,
     Globalpay,
     Klarna,
@@ -566,6 +567,7 @@ pub enum RoutableConnectors {
     Stripe,
     Worldline,
     Worldpay,
+    Bambora,
 }
 
 /// Wallets which support obtaining session object

--- a/crates/router/src/configs/settings.rs
+++ b/crates/router/src/configs/settings.rs
@@ -153,6 +153,7 @@ pub struct Connectors {
 
     // Keep this field separate from the remaining fields
     pub supported: SupportedConnectors,
+	pub bambora: ConnectorParams,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/crates/router/src/connector.rs
+++ b/crates/router/src/connector.rs
@@ -16,9 +16,12 @@ pub mod utils;
 pub mod worldline;
 pub mod worldpay;
 
+pub mod bambora;
+
 pub use self::{
     aci::Aci, adyen::Adyen, applepay::Applepay, authorizedotnet::Authorizedotnet,
     braintree::Braintree, checkout::Checkout, cybersource::Cybersource, fiserv::Fiserv,
     globalpay::Globalpay, klarna::Klarna, payu::Payu, rapyd::Rapyd, shift4::Shift4, stripe::Stripe,
     worldline::Worldline, worldpay::Worldpay,
+bambora::Bambora,
 };

--- a/crates/router/src/connector/bambora.rs
+++ b/crates/router/src/connector/bambora.rs
@@ -6,6 +6,7 @@ use error_stack::{ResultExt, IntoReport};
 use crate::{
     configs::settings,
     utils::{self, BytesExt},
+    consts,
     core::{
         errors::{self, CustomResult},
         payments,
@@ -81,13 +82,82 @@ impl
 
 impl api::PaymentVoid for Bambora {}
 
-impl
-    ConnectorIntegration<
-        api::Void,
-        types::PaymentsCancelData,
-        types::PaymentsResponseData,
-    > for Bambora
-{}
+
+impl ConnectorIntegration<api::Void, types::PaymentsCancelData, types::PaymentsResponseData>
+    for Bambora
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsCancelRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        req: &types::PaymentsCancelRouterData,
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        let connector_payment_id = req.request.connector_transaction_id.clone();
+        Ok(format!(
+            "{}/v1/payments/{}/void",
+            self.base_url(_connectors),
+            connector_payment_id
+        ))
+    }
+
+    fn get_request_body(
+        &self,
+        req: &types::PaymentsCancelRouterData,
+    ) -> CustomResult<Option<String>, errors::ConnectorError> {
+        Ok(Some("{}".to_string()))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsCancelRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Post)
+                .url(&types::PaymentsVoidType::get_url(self, req, connectors)?)
+                .headers(types::PaymentsVoidType::get_headers(self, req, connectors)?)
+                .body(self.get_request_body(req)?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsCancelRouterData,
+        res: Response,
+    ) -> CustomResult<types::PaymentsCancelRouterData, errors::ConnectorError> {
+        let response: bambora::BamboraPaymentsResponse = res
+            .response
+            .parse_struct("bambora PaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
 
 impl api::ConnectorAccessToken for Bambora {}
 
@@ -175,78 +245,95 @@ impl
         types::PaymentsResponseData,
     > for Bambora
 {
-    fn get_headers(
-        &self,
-        req: &types::PaymentsCaptureRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
-        self.build_headers(req, connectors)
-    }
-
-    fn get_content_type(&self) -> &'static str {
-        // application/json
-        self.common_get_content_type()
-    }
-
-    fn get_url(
-        &self,
-        _req: &types::PaymentsCaptureRouterData,
-        _connectors: &settings::Connectors,
-    ) -> CustomResult<String, errors::ConnectorError> {
-        Ok(format!(
-            "{}v1/payments/{{transId}}/completions",
-            self.base_url(_connectors)
-        ))
-    }
-
-    fn get_request_body(
-        &self,
-        _req: &types::PaymentsCaptureRouterData,
-    ) -> CustomResult<Option<String>, errors::ConnectorError> {
-        todo!()
-    }
-
-    fn build_request(
-        &self,
-        req: &types::PaymentsCaptureRouterData,
-        connectors: &settings::Connectors,
-    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
-        Ok(Some(
-            services::RequestBuilder::new()
-                .method(services::Method::Post)
-                .url(&types::PaymentsCaptureType::get_url(self, req, connectors)?)
-                .headers(types::PaymentsCaptureType::get_headers(
-                    self, req, connectors,
-                )?)
-                .build(),
-        ))
-    }
-
-    fn handle_response(
-        &self,
-        data: &types::PaymentsCaptureRouterData,
-        res: Response,
-    ) -> CustomResult<types::PaymentsCaptureRouterData, errors::ConnectorError> {
-        let response: bambora::BamboraPaymentsResponse = res
-            .response
-            .parse_struct("Bambora PaymentsResponse")
-            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
-        logger::debug!(bamborapayments_create_response=?response);
-        types::ResponseRouterData {
-            response,
-            data: data.clone(),
-            http_code: res.status_code,
+        fn get_headers(
+            &self,
+            req: &types::PaymentsCaptureRouterData,
+            connectors: &settings::Connectors,
+        ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+            self.build_headers(req, connectors)
         }
-        .try_into()
-        .change_context(errors::ConnectorError::ResponseHandlingFailed)
-    }
-
-    fn get_error_response(
-        &self,
-        res: Response,
-    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
-        self.build_error_response(res)
-    }
+    
+        fn get_content_type(&self) -> &'static str {
+            self.common_get_content_type()
+        }
+    
+        fn get_url(
+            &self,
+            _req: &types::PaymentsCaptureRouterData,
+            connectors: &settings::Connectors,
+        ) -> CustomResult<String, errors::ConnectorError> {
+            Ok(format!("{}{}", self.base_url(connectors), "v1/payments"))
+        }
+    
+        fn get_request_body(
+            &self,
+            req: &types::PaymentsCaptureRouterData,
+        ) -> CustomResult<Option<String>, errors::ConnectorError> {
+            let req_obj = bambora::BamboraPaymentsRequest::try_from(req)?;
+            let bambora_req =
+                utils::Encode::<bambora::BamboraPaymentsRequest>::encode_to_string_of_json(&req_obj)
+                    .change_context(errors::ConnectorError::RequestEncodingFailed)?;
+            Ok(Some(bambora_req))
+        }
+    
+        fn build_request(
+            &self,
+            req: &types::PaymentsCaptureRouterData,
+            connectors: &settings::Connectors,
+        ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+            Ok(Some(
+                services::RequestBuilder::new()
+                    .method(services::Method::Post)
+                    .url(&types::PaymentsCaptureType::get_url(self, req, connectors)?)
+                    .headers(types::PaymentsCaptureType::get_headers(
+                        self, req, connectors,
+                    )?)
+                    .body(types::PaymentsCaptureType::get_request_body(self, req)?)
+                    .build(),
+            ))
+        }
+    
+        fn handle_response(
+            &self,
+            data: &types::PaymentsCaptureRouterData,
+            res: Response,
+        ) -> CustomResult<types::PaymentsCaptureRouterData, errors::ConnectorError> {
+            let response: bambora::BamboraPaymentsResponse = res
+                .response
+                .parse_struct("Bambora PaymentsResponse")
+                .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+            types::ResponseRouterData {
+                response,
+                data: data.clone(),
+                http_code: res.status_code,
+            }
+            .try_into()
+            .change_context(errors::ConnectorError::ResponseHandlingFailed)
+        }
+    
+        // fn get_error_response(
+        //     &self,
+        //     res: Response,
+        // ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        //     self.build_error_response(res)
+        // }
+    
+        fn get_error_response(
+            &self,
+            res: Response,
+        ) -> CustomResult<types::ErrorResponse, errors::ConnectorError> {
+            let response: bambora::BamboraErrorResponse = res
+                .response
+                .parse_struct("Bambora ErrorResponse")
+                .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+    
+            Ok(types::ErrorResponse {
+                status_code: res.status_code,
+                code: consts::NO_ERROR_CODE.to_string(),
+                message: response.error.message,
+                reason: None,
+            })
+        }
 }
 
 impl api::PaymentSession for Bambora {}

--- a/crates/router/src/connector/bambora.rs
+++ b/crates/router/src/connector/bambora.rs
@@ -33,13 +33,13 @@ where
         _connectors: &settings::Connectors,
     ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
         // todo!()
-        let headers:Vec(String, String) = vec![
+        let mut headers = vec![
             (
                 headers::CONTENT_TYPE.to_string(),
                 self.get_content_type().to_string(),
             ),
         ];
-        let mut api_key:Vec(String, String)=self.get_auth_header(&_req.connector_auth_type)?;
+        let mut api_key=self.get_auth_header(&_req.connector_auth_type)?;
         headers.append(&mut api_key);
         Ok(headers)
     }
@@ -119,7 +119,7 @@ impl
         _req: &types::PaymentsSyncRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
-        println!("Reached some code!")
+        println!("Reached some code!");
         Ok(format!(
             "{}payments/{}",
             self.base_url(_connectors),
@@ -283,6 +283,7 @@ impl
         _req: &types::PaymentsAuthorizeRouterData, 
         _connectors: &settings::Connectors,
     ) -> CustomResult<String,errors::ConnectorError> {
+        println!("{:?}",self.base_url(_connectors));
         Ok(format!(
             "{}{}",
             self.base_url(_connectors),
@@ -301,6 +302,8 @@ impl
         req: &types::PaymentsAuthorizeRouterData,
         connectors: &settings::Connectors,
     ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        println!("Headers---:{:?}",self.get_headers(req, connectors));
+        println!("Body---:{:?}",self.get_request_body(req));
         Ok(Some(
             services::RequestBuilder::new()
                 .method(services::Method::Post)
@@ -320,6 +323,8 @@ impl
         data: &types::PaymentsAuthorizeRouterData,
         res: Response,
     ) -> CustomResult<types::PaymentsAuthorizeRouterData,errors::ConnectorError> {
+        println!("Reached handle_response");
+        println!("Handle Response---:{:?}",res.response);
         let response: bambora::BamboraPaymentsResponse = res.response.parse_struct("PaymentIntentResponse").change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         logger::debug!(bamborapayments_create_response=?response);
         types::ResponseRouterData {

--- a/crates/router/src/connector/bambora.rs
+++ b/crates/router/src/connector/bambora.rs
@@ -119,7 +119,6 @@ impl
         _req: &types::PaymentsSyncRouterData,
         _connectors: &settings::Connectors,
     ) -> CustomResult<String, errors::ConnectorError> {
-        println!("Reached some code!");
         Ok(format!(
             "{}payments/{}",
             self.base_url(_connectors),
@@ -283,7 +282,6 @@ impl
         _req: &types::PaymentsAuthorizeRouterData, 
         _connectors: &settings::Connectors,
     ) -> CustomResult<String,errors::ConnectorError> {
-        println!("{:?}",self.base_url(_connectors));
         Ok(format!(
             "{}{}",
             self.base_url(_connectors),
@@ -302,8 +300,6 @@ impl
         req: &types::PaymentsAuthorizeRouterData,
         connectors: &settings::Connectors,
     ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
-        println!("Headers---:{:?}",self.get_headers(req, connectors));
-        println!("Body---:{:?}",self.get_request_body(req));
         Ok(Some(
             services::RequestBuilder::new()
                 .method(services::Method::Post)
@@ -323,8 +319,6 @@ impl
         data: &types::PaymentsAuthorizeRouterData,
         res: Response,
     ) -> CustomResult<types::PaymentsAuthorizeRouterData,errors::ConnectorError> {
-        println!("Reached handle_response");
-        println!("Handle Response---:{:?}",res.response);
         let response: bambora::BamboraPaymentsResponse = res.response.parse_struct("PaymentIntentResponse").change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
         logger::debug!(bamborapayments_create_response=?response);
         types::ResponseRouterData {
@@ -361,8 +355,9 @@ impl
 
     fn get_url(&self, _req: &types::RefundsRouterData<api::Execute>, _connectors: &settings::Connectors,) -> CustomResult<String,errors::ConnectorError> {
         Ok(format!(
-            "{}ch/payments/v1/charges",
-            self.base_url(_connectors)
+            "{}v1/payments/{}/returns",
+            self.base_url(_connectors),
+            _req.request.connector_transaction_id,
         ))
     }
 

--- a/crates/router/src/connector/bambora.rs
+++ b/crates/router/src/connector/bambora.rs
@@ -1,0 +1,484 @@
+mod transformers;
+
+use std::fmt::Debug;
+use error_stack::{ResultExt, IntoReport};
+
+use crate::{
+    configs::settings,
+    utils::{self, BytesExt},
+    core::{
+        errors::{self, CustomResult},
+        payments,
+    },
+    headers, logger, services::{self, ConnectorIntegration},
+    types::{
+        self,
+        api::{self, ConnectorCommon, ConnectorCommonExt},
+        ErrorResponse, Response,
+    }
+};
+
+
+use transformers as bambora;
+
+#[derive(Debug, Clone)]
+pub struct Bambora;
+
+impl<Flow, Request, Response> ConnectorCommonExt<Flow, Request, Response> for Bambora 
+where
+    Self: ConnectorIntegration<Flow, Request, Response>,{
+    fn build_headers(
+        &self,
+        _req: &types::RouterData<Flow, Request, Response>,
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        // todo!()
+        let headers:Vec(String, String) = vec![
+            (
+                headers::CONTENT_TYPE.to_string(),
+                self.get_content_type().to_string(),
+            ),
+        ];
+        let mut api_key:Vec(String, String)=self.get_auth_header(&_req.connector_auth_type)?;
+        headers.append(&mut api_key);
+        Ok(headers)
+    }
+}
+
+impl ConnectorCommon for Bambora {
+    fn id(&self) -> &'static str {
+        "bambora"
+    }
+
+    fn common_get_content_type(&self) -> &'static str {
+        // todo!()
+        "application/json"
+    }
+
+    fn base_url<'a>(&self, connectors: &'a settings::Connectors) -> &'a str {
+        connectors.bambora.base_url.as_ref()
+    }
+
+    fn get_auth_header(&self, auth_type:&types::ConnectorAuthType)-> CustomResult<Vec<(String,String)>,errors::ConnectorError> {
+        let auth: bambora::BamboraAuthType = auth_type
+            .try_into()
+            .change_context(errors::ConnectorError::FailedToObtainAuthType)?;
+        Ok(vec![(headers::AUTHORIZATION.to_string(), format!("Passcode {}", auth.api_key))])
+    }
+}
+
+impl api::Payment for Bambora {}
+
+impl api::PreVerify for Bambora {}
+impl
+    ConnectorIntegration<
+        api::Verify,
+        types::VerifyRequestData,
+        types::PaymentsResponseData,
+    > for Bambora
+{
+}
+
+impl api::PaymentVoid for Bambora {}
+
+impl
+    ConnectorIntegration<
+        api::Void,
+        types::PaymentsCancelData,
+        types::PaymentsResponseData,
+    > for Bambora
+{}
+
+impl api::ConnectorAccessToken for Bambora {}
+
+impl ConnectorIntegration<api::AccessTokenAuth, types::AccessTokenRequestData, types::AccessToken>
+    for Bambora
+{
+}
+
+impl api::PaymentSync for Bambora {}
+impl
+    ConnectorIntegration<api::PSync, types::PaymentsSyncData, types::PaymentsResponseData>
+    for Bambora
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        // application/json is given by function
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        _req: &types::PaymentsSyncRouterData,
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        println!("Reached some code!")
+        Ok(format!(
+            "{}payments/{}",
+            self.base_url(_connectors),
+            String::from("temp")
+        ))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Get)
+                .url(&types::PaymentsSyncType::get_url(self, req, connectors)?)
+                .headers(types::PaymentsSyncType::get_headers(self, req, connectors)?)
+                .build(),
+        ))
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsSyncRouterData,
+        res: Response,
+    ) -> CustomResult<types::PaymentsSyncRouterData, errors::ConnectorError> {
+        logger::debug!(payment_sync_response=?res);
+        let response: bambora:: BamboraPaymentsResponse = res
+            .response
+            .parse_struct("bambora PaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        types::RouterData::try_from(types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        })
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+}
+
+
+impl api::PaymentCapture for Bambora {}
+impl
+    ConnectorIntegration<
+        api::Capture,
+        types::PaymentsCaptureData,
+        types::PaymentsResponseData,
+    > for Bambora
+{
+    fn get_headers(
+        &self,
+        req: &types::PaymentsCaptureRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Vec<(String, String)>, errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        // application/json
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self,
+        _req: &types::PaymentsCaptureRouterData,
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        Ok(format!(
+            "{}v1/payments/{{transId}}/completions",
+            self.base_url(_connectors)
+        ))
+    }
+
+    fn get_request_body(
+        &self,
+        _req: &types::PaymentsCaptureRouterData,
+    ) -> CustomResult<Option<String>, errors::ConnectorError> {
+        todo!()
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsCaptureRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Post)
+                .url(&types::PaymentsCaptureType::get_url(self, req, connectors)?)
+                .headers(types::PaymentsCaptureType::get_headers(
+                    self, req, connectors,
+                )?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsCaptureRouterData,
+        res: Response,
+    ) -> CustomResult<types::PaymentsCaptureRouterData, errors::ConnectorError> {
+        let response: bambora::BamboraPaymentsResponse = res
+            .response
+            .parse_struct("Bambora PaymentsResponse")
+            .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        logger::debug!(bamborapayments_create_response=?response);
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(
+        &self,
+        res: Response,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+impl api::PaymentSession for Bambora {}
+
+impl
+    ConnectorIntegration<
+        api::Session,
+        types::PaymentsSessionData,
+        types::PaymentsResponseData,
+    > for Bambora
+{
+    //TODO: implement sessions flow
+}
+
+impl api::PaymentAuthorize for Bambora {}
+
+impl
+    ConnectorIntegration<
+        api::Authorize,
+        types::PaymentsAuthorizeData,
+        types::PaymentsResponseData,
+    > for Bambora {
+    fn get_headers(&self, req: &types::PaymentsAuthorizeRouterData, connectors: &settings::Connectors,) -> CustomResult<Vec<(String, String)>,errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(
+        &self, 
+        _req: &types::PaymentsAuthorizeRouterData, 
+        _connectors: &settings::Connectors,
+    ) -> CustomResult<String,errors::ConnectorError> {
+        Ok(format!(
+            "{}{}",
+            self.base_url(_connectors),
+            "v1/payments"
+        ))
+    }
+
+    fn get_request_body(&self, req: &types::PaymentsAuthorizeRouterData) -> CustomResult<Option<String>,errors::ConnectorError> {
+        let bambora_req =
+            utils::Encode::<bambora::BamboraPaymentsRequest>::convert_and_encode(req).change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        Ok(Some(bambora_req))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::PaymentsAuthorizeRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Post)
+                .url(&types::PaymentsAuthorizeType::get_url(
+                    self, req, connectors,
+                )?)
+                .headers(types::PaymentsAuthorizeType::get_headers(
+                    self, req, connectors,
+                )?)
+                .body(types::PaymentsAuthorizeType::get_request_body(self, req)?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::PaymentsAuthorizeRouterData,
+        res: Response,
+    ) -> CustomResult<types::PaymentsAuthorizeRouterData,errors::ConnectorError> {
+        let response: bambora::BamboraPaymentsResponse = res.response.parse_struct("PaymentIntentResponse").change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        logger::debug!(bamborapayments_create_response=?response);
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(&self, res: Response) -> CustomResult<ErrorResponse,errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+impl api::Refund for Bambora {}
+impl api::RefundExecute for Bambora {}
+impl api::RefundSync for Bambora {}
+
+impl
+    ConnectorIntegration<
+        api::Execute,
+        types::RefundsData,
+        types::RefundsResponseData,
+    > for Bambora {
+    fn get_headers(&self, req: &types::RefundsRouterData<api::Execute>, connectors: &settings::Connectors,) -> CustomResult<Vec<(String,String)>,errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(&self, _req: &types::RefundsRouterData<api::Execute>, _connectors: &settings::Connectors,) -> CustomResult<String,errors::ConnectorError> {
+        Ok(format!(
+            "{}ch/payments/v1/charges",
+            self.base_url(_connectors)
+        ))
+    }
+
+    fn get_request_body(&self, req: &types::RefundsRouterData<api::Execute>) -> CustomResult<Option<String>,errors::ConnectorError> {
+        let bambora_req = utils::Encode::<bambora::BamboraRefundRequest>::convert_and_encode(req).change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        Ok(Some(bambora_req))
+    }
+
+    fn build_request(&self, req: &types::RefundsRouterData<api::Execute>, connectors: &settings::Connectors,) -> CustomResult<Option<services::Request>,errors::ConnectorError> {
+        let request = services::RequestBuilder::new()
+            .method(services::Method::Post)
+            .url(&types::RefundExecuteType::get_url(self, req, connectors)?)
+            .headers(types::RefundExecuteType::get_headers(self, req, connectors)?)
+            .body(types::RefundExecuteType::get_request_body(self, req)?)
+            .build();
+        Ok(Some(request))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::RefundsRouterData<api::Execute>,
+        res: Response,
+    ) -> CustomResult<types::RefundsRouterData<api::Execute>,errors::ConnectorError> {
+        logger::debug!(target: "router::connector::bambora", response=?res);
+        let response: bambora::RefundResponse = res.response.parse_struct("bambora RefundResponse").change_context(errors::ConnectorError::RequestEncodingFailed)?;
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(&self, res: Response) -> CustomResult<ErrorResponse,errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+impl
+    ConnectorIntegration<api::RSync, types::RefundsData, types::RefundsResponseData> for Bambora {
+    fn get_headers(&self, req: &types::RefundSyncRouterData,connectors: &settings::Connectors,) -> CustomResult<Vec<(String, String)>,errors::ConnectorError> {
+        self.build_headers(req, connectors)
+    }
+
+    fn get_content_type(&self) -> &'static str {
+        self.common_get_content_type()
+    }
+
+    fn get_url(&self, _req: &types::RefundSyncRouterData,_connectors: &settings::Connectors,) -> CustomResult<String,errors::ConnectorError> {
+        Ok(format!(
+            "{}ch/payments/v1/charges",
+            self.base_url(_connectors)
+        ))
+    }
+
+    fn build_request(
+        &self,
+        req: &types::RefundSyncRouterData,
+        connectors: &settings::Connectors,
+    ) -> CustomResult<Option<services::Request>, errors::ConnectorError> {
+        Ok(Some(
+            services::RequestBuilder::new()
+                .method(services::Method::Get)
+                .url(&types::RefundSyncType::get_url(self, req, connectors)?)
+                .headers(types::RefundSyncType::get_headers(self, req, connectors)?)
+                .body(types::RefundSyncType::get_request_body(self, req)?)
+                .build(),
+        ))
+    }
+
+    fn handle_response(
+        &self,
+        data: &types::RefundSyncRouterData,
+        res: Response,
+    ) -> CustomResult<types::RefundSyncRouterData,errors::ConnectorError,> {
+        logger::debug!(target: "router::connector::bambora", response=?res);
+        let response: bambora::RefundResponse = res.response.parse_struct("bambora RefundResponse").change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+        types::ResponseRouterData {
+            response,
+            data: data.clone(),
+            http_code: res.status_code,
+        }
+        .try_into()
+        .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response(&self, res: Response) -> CustomResult<ErrorResponse,errors::ConnectorError> {
+        self.build_error_response(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl api::IncomingWebhook for Bambora {
+    fn get_webhook_object_reference_id(
+        &self,
+        _body: &[u8],
+    ) -> CustomResult<String, errors::ConnectorError> {
+        Err(errors::ConnectorError::WebhooksNotImplemented).into_report()
+    }
+
+    fn get_webhook_event_type(
+        &self,
+        _body: &[u8],
+    ) -> CustomResult<api::IncomingWebhookEvent, errors::ConnectorError> {
+        Err(errors::ConnectorError::WebhooksNotImplemented).into_report()
+    }
+
+    fn get_webhook_resource_object(
+        &self,
+        _body: &[u8],
+    ) -> CustomResult<serde_json::Value, errors::ConnectorError> {
+        Err(errors::ConnectorError::WebhooksNotImplemented).into_report()
+    }
+}
+
+impl services::ConnectorRedirectResponse for Bambora {
+    fn get_flow_type(
+        &self,
+        _query_params: &str,
+    ) -> CustomResult<payments::CallConnectorAction, errors::ConnectorError> {
+        Ok(payments::CallConnectorAction::Trigger)
+    }
+}

--- a/crates/router/src/connector/bambora/transformers.rs
+++ b/crates/router/src/connector/bambora/transformers.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
-use common_utils::{pii};
-use error_stack::{report, IntoReport};
-use masking::{Secret};
+// use common_utils::{pii};
+// use error_stack::{report, IntoReport};
+// use masking::{Secret};
 use serde::{Deserialize, Serialize};
 use crate::{core::errors,pii::PeekInterface,types::{self,api, storage::enums}};
 

--- a/crates/router/src/connector/bambora/transformers.rs
+++ b/crates/router/src/connector/bambora/transformers.rs
@@ -1,0 +1,229 @@
+use std::fmt::Debug;
+use common_utils::{pii};
+use error_stack::{report, IntoReport};
+use masking::{Secret};
+use serde::{Deserialize, Serialize};
+use crate::{core::errors,pii::PeekInterface,types::{self,api, storage::enums}};
+
+#[derive(Debug, Serialize, Deserialize)]
+enum PaymentMethod {
+    InputCardDetails,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InputCardDetails {
+    name: String,
+    number: String,
+    expiry_month: String,
+    expiry_year: String,
+    cvd: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Custom {
+    ref1: String,
+    ref2: String,
+    ref3: String,
+    ref4: String,
+    ref5: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Card {
+    card_type: String,
+    last_four: String,
+    card_bin: String,
+    address_match: i64,
+    postal_result: i64,
+    avs_result: String,
+    cvd_result: String,
+    cavv_result: String,
+    avs: Avs,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Avs {
+    id: String,
+    message: String,
+    processed: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Link {
+    rel: String,
+    href: String,
+    method: String,
+}
+
+//TODO: Fill the struct with respective fields
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BamboraPaymentsRequest {
+    amount: i64,
+    payment_method: String,
+    card: InputCardDetails,
+}
+
+impl TryFrom<&types::PaymentsAuthorizeRouterData> for BamboraPaymentsRequest  {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(_item: &types::PaymentsAuthorizeRouterData) -> Result<Self,Self::Error> {
+        let card_details:InputCardDetails = match _item.request.payment_method_data {
+            api::PaymentMethod::Card(ref ccard) => InputCardDetails{
+                name:ccard.card_holder_name.peek().clone(),
+                number:ccard.card_number.peek().clone(),
+                expiry_month:ccard.card_exp_month.peek().clone(),
+                expiry_year: ccard.card_exp_year.peek().clone(),
+                cvd:ccard.card_cvc.peek().clone()
+            },
+            _ => Err(errors::ConnectorError::NotImplemented("payment method".into()))?,
+        };
+        let payment_method_name:String = match _item.payment_method {
+            storage_models::enums::PaymentMethodType::Card => String::from("card"),
+            _ => Err(errors::ConnectorError::NotImplemented("payment method".into()))?,
+        };
+
+        Ok(Self {
+            amount: _item.request.amount,
+            payment_method: payment_method_name,
+            card: card_details
+        })
+    }
+}
+
+//TODO: Fill the struct with respective fields
+// Auth Struct
+pub struct BamboraAuthType {
+    pub(super) api_key: String
+}
+
+impl TryFrom<&types::ConnectorAuthType> for BamboraAuthType  {
+    type Error = error_stack::Report<errors::ConnectorError>;
+    fn try_from(_auth_type: &types::ConnectorAuthType) -> Result<Self, Self::Error> {
+        // todo!()
+        // Err
+        Err(errors::ConnectorError::NotImplemented("payment method".into())).into_report()
+    }
+}
+// PaymentsResponse
+//TODO: Append the remaining status flags
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum BamboraPaymentStatus {
+    Succeeded,
+    Failed,
+    #[default]
+    Processing,
+}
+
+impl From<BamboraPaymentStatus> for enums::AttemptStatus {
+    fn from(item: BamboraPaymentStatus) -> Self {
+        match item {
+            BamboraPaymentStatus::Succeeded => Self::Charged,
+            BamboraPaymentStatus::Failed => Self::Failure,
+            BamboraPaymentStatus::Processing => Self::Authorizing,
+        }
+    }
+}
+
+//TODO: Fill the struct with respective fields
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BamboraPaymentsResponse {
+    id: String,
+    authorizing_merchant_id: i64,
+    approved: String,
+    message_id: String,
+    message: String,
+    auth_code: String,
+    created: String,
+    order_number: String,
+    #[serde(rename="type")]
+    flow_type: String,
+    payment_method: String,
+    risk_score: f64,
+    amount: f64,
+    custom: Custom,
+    card: Card,
+    links: Vec<Link>
+}
+
+impl<F,T> TryFrom<types::ResponseRouterData<F, BamboraPaymentsResponse, T, types::PaymentsResponseData>> for types::RouterData<F, T, types::PaymentsResponseData> {
+    type Error = error_stack::Report<errors::ParsingError>;
+    fn try_from(item: types::ResponseRouterData<F, BamboraPaymentsResponse, T, types::PaymentsResponseData>) -> Result<Self,Self::Error> {
+        Ok(Self {
+            status: enums::AttemptStatus::Charged,
+            response: Ok(types::PaymentsResponseData::TransactionResponse {
+                resource_id: types::ResponseId::ConnectorTransactionId(item.response.id),
+                redirection_data: None,
+                redirect: false,
+                mandate_reference: None,
+                connector_metadata: None,
+            }),
+            ..item.data
+        })
+    }
+}
+
+//TODO: Fill the struct with respective fields
+// REFUND :
+// Type definition for RefundRequest
+#[derive(Default, Debug, Serialize)]
+pub struct BamboraRefundRequest {}
+
+impl<F> TryFrom<&types::RefundsRouterData<F>> for BamboraRefundRequest {
+    type Error = error_stack::Report<errors::ParsingError>;
+    fn try_from(_item: &types::RefundsRouterData<F>) -> Result<Self,Self::Error> {
+       todo!()
+    
+    }
+}
+
+// Type definition for Refund Response
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Default, Deserialize, Clone)]
+pub enum RefundStatus {
+    Succeeded,
+    Failed,
+    #[default]
+    Processing,
+}
+
+impl From<RefundStatus> for enums::RefundStatus {
+    fn from(item: RefundStatus) -> Self {
+        match item {
+            RefundStatus::Succeeded => Self::Success,
+            RefundStatus::Failed => Self::Failure,
+            RefundStatus::Processing => Self::Pending,
+            //TODO: Review mapping
+        }
+    }
+}
+
+//TODO: Fill the struct with respective fields
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct RefundResponse {
+}
+
+impl TryFrom<types::RefundsResponseRouterData<api::Execute, RefundResponse>>
+    for types::RefundsRouterData<api::Execute>
+{
+    type Error = error_stack::Report<errors::ParsingError>;
+    fn try_from(
+        _item: types::RefundsResponseRouterData<api::Execute, RefundResponse>,
+    ) -> Result<Self, Self::Error> {
+        todo!()
+        // Err(errors::ConnectorError::NotImplemented("payment method".into())).into_report()
+    }
+}
+
+impl TryFrom<types::RefundsResponseRouterData<api::RSync, RefundResponse>> for types::RefundsRouterData<api::RSync>
+{
+     type Error = error_stack::Report<errors::ParsingError>;
+    fn try_from(_item: types::RefundsResponseRouterData<api::RSync, RefundResponse>) -> Result<Self,Self::Error> {
+         todo!()
+        // Err(errors::ConnectorError::NotImplemented("payment method".into())).into_report()
+     }
+ }
+
+//TODO: Fill the struct with respective fields
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq)]
+pub struct BamboraErrorResponse {}

--- a/crates/router/src/connector/bambora/transformers.rs
+++ b/crates/router/src/connector/bambora/transformers.rs
@@ -63,11 +63,11 @@ pub struct BamboraPaymentsRequest {
     card: InputCardDetails,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct BamboraRefundRequest {
-    amount: i64,
-    
-}
+// #[derive(Debug, Serialize, Deserialize)]
+// pub struct BamboraRefundRequest {
+//     amount: i64,
+
+// }
 
 impl TryFrom<&types::PaymentsAuthorizeRouterData> for BamboraPaymentsRequest  {
     type Error = error_stack::Report<errors::ConnectorError>;

--- a/crates/router/src/types/api.rs
+++ b/crates/router/src/types/api.rs
@@ -176,7 +176,8 @@ impl ConnectorData {
             "stripe" => Ok(Box::new(&connector::Stripe)),
             "worldline" => Ok(Box::new(&connector::Worldline)),
             "worldpay" => Ok(Box::new(&connector::Worldpay)),
-            _ => Err(report!(errors::ConnectorError::InvalidConnectorName)
+            "bambora" => Ok(Box::new(&connector::Bambora)),
+			_ => Err(report!(errors::ConnectorError::InvalidConnectorName)
                 .attach_printable(format!("invalid connector name: {connector_name}")))
             .change_context(errors::ApiErrorResponse::InternalServerError),
         }

--- a/crates/router/tests/connectors/bambora.rs
+++ b/crates/router/tests/connectors/bambora.rs
@@ -1,0 +1,438 @@
+use masking::Secret;
+use router::types::{self, api, storage::enums};
+
+use crate::{
+    connector_auth,
+    utils::{self, ConnectorActions},
+};
+
+#[derive(Clone, Copy)]
+struct BamboraTest;
+impl ConnectorActions for BamboraTest {}
+impl utils::Connector for BamboraTest {
+    fn get_data(&self) -> types::api::ConnectorData {
+        use router::connector::Bambora;
+        types::api::ConnectorData {
+            connector: Box::new(&Bambora),
+            connector_name: types::Connector::Bambora,
+            get_token: types::api::GetToken::Connector,
+        }
+    }
+
+    fn get_auth_token(&self) -> types::ConnectorAuthType {
+        types::ConnectorAuthType::from(
+            connector_auth::ConnectorAuthentication::new()
+                .bambora
+                .expect("Missing connector authentication configuration"),
+        )
+    }
+
+    fn get_name(&self) -> String {
+        "bambora".to_string()
+    }
+}
+
+static CONNECTOR: BamboraTest = BamboraTest {};
+
+// Cards Positive Tests
+// Creates a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_only_authorize_payment() {
+    let response = CONNECTOR
+        .authorize_payment(None, None)
+        .await
+        .expect("Authorize payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Authorized);
+}
+
+// Captures a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_capture_authorized_payment() {
+    let response = CONNECTOR
+        .authorize_and_capture_payment(None, None, None)
+        .await
+        .expect("Capture payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Charged);
+}
+
+// Partially captures a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_partially_capture_authorized_payment() {
+    let response = CONNECTOR
+        .authorize_and_capture_payment(
+            None,
+            Some(types::PaymentsCaptureData {
+                amount_to_capture: Some(50),
+                ..utils::PaymentCaptureType::default().0
+            }),
+            None,
+        )
+        .await
+        .expect("Capture payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Charged);
+}
+
+// Synchronizes a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_sync_authorized_payment() {
+    let authorize_response = CONNECTOR
+        .authorize_payment(None, None)
+        .await
+        .expect("Authorize payment response");
+    let txn_id = utils::get_connector_transaction_id(authorize_response.response);
+    let response = CONNECTOR
+        .psync_retry_till_status_matches(
+            enums::AttemptStatus::Authorized,
+            Some(types::PaymentsSyncData {
+                connector_transaction_id: router::types::ResponseId::ConnectorTransactionId(
+                    txn_id.unwrap(),
+                ),
+                encoded_data: None,
+                capture_method: None,
+            }),
+            None,
+        )
+        .await
+        .expect("PSync response");
+    assert_eq!(response.status, enums::AttemptStatus::Authorized,);
+}
+
+// Voids a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_void_authorized_payment() {
+    let response = CONNECTOR
+        .authorize_and_void_payment(
+            None,
+            Some(types::PaymentsCancelData {
+                connector_transaction_id: String::from(""),
+                cancellation_reason: Some("requested_by_customer".to_string()),
+            }),
+            None,
+        )
+        .await
+        .expect("Void payment response");
+    assert_eq!(response.status, enums::AttemptStatus::Voided);
+}
+
+// Refunds a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_refund_manually_captured_payment() {
+    let response = CONNECTOR
+        .capture_payment_and_refund(None, None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Partially refunds a payment using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_partially_refund_manually_captured_payment() {
+    let response = CONNECTOR
+        .capture_payment_and_refund(
+            None,
+            None,
+            Some(types::RefundsData {
+                refund_amount: 50,
+                ..utils::PaymentRefundType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Synchronizes a refund using the manual capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_sync_manually_captured_refund() {
+    let refund_response = CONNECTOR
+        .capture_payment_and_refund(None, None, None, None)
+        .await
+        .unwrap();
+    let response = CONNECTOR
+        .rsync_retry_till_status_matches(
+            enums::RefundStatus::Success,
+            refund_response.response.unwrap().connector_refund_id,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Creates a payment using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_make_payment() {
+    let authorize_response = CONNECTOR.make_payment(None, None).await.unwrap();
+    assert_eq!(authorize_response.status, enums::AttemptStatus::Charged);
+}
+
+// Synchronizes a payment using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_sync_auto_captured_payment() {
+    let authorize_response = CONNECTOR.make_payment(None, None).await.unwrap();
+    assert_eq!(authorize_response.status, enums::AttemptStatus::Charged);
+    let txn_id = utils::get_connector_transaction_id(authorize_response.response);
+    assert_ne!(txn_id, None, "Empty connector transaction id");
+    let response = CONNECTOR
+        .psync_retry_till_status_matches(
+            enums::AttemptStatus::Charged,
+            Some(types::PaymentsSyncData {
+                connector_transaction_id: router::types::ResponseId::ConnectorTransactionId(
+                    txn_id.unwrap(),
+                ),
+                encoded_data: None,
+                capture_method: None,
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status, enums::AttemptStatus::Charged,);
+}
+
+// Refunds a payment using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_refund_auto_captured_payment() {
+    let response = CONNECTOR
+        .make_payment_and_refund(None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Partially refunds a payment using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_partially_refund_succeeded_payment() {
+    let refund_response = CONNECTOR
+        .make_payment_and_refund(
+            None,
+            Some(types::RefundsData {
+                refund_amount: 50,
+                ..utils::PaymentRefundType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        refund_response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Creates multiple refunds against a payment using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_refund_succeeded_payment_multiple_times() {
+    CONNECTOR
+        .make_payment_and_multiple_refund(
+            None,
+            Some(types::RefundsData {
+                refund_amount: 50,
+                ..utils::PaymentRefundType::default().0
+            }),
+            None,
+        )
+        .await;
+}
+
+// Synchronizes a refund using the automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_sync_refund() {
+    let refund_response = CONNECTOR
+        .make_payment_and_refund(None, None, None)
+        .await
+        .unwrap();
+    let response = CONNECTOR
+        .rsync_retry_till_status_matches(
+            enums::RefundStatus::Success,
+            refund_response.response.unwrap().connector_refund_id,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap().refund_status,
+        enums::RefundStatus::Success,
+    );
+}
+
+// Cards Negative scenerios
+// Creates a payment with incorrect card number.
+#[actix_web::test]
+async fn should_fail_payment_for_incorrect_card_number() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_number: Secret::new("1234567891011".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Your card number is incorrect.".to_string(),
+    );
+}
+
+// Creates a payment with empty card number.
+#[actix_web::test]
+async fn should_fail_payment_for_empty_card_number() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_number: Secret::new(String::from("")),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    let x = response.response.unwrap_err();
+    assert_eq!(
+        x.message,
+        "You passed an empty string for 'payment_method_data[card][number]'.",
+    );
+}
+
+// Creates a payment with incorrect CVC.
+#[actix_web::test]
+async fn should_fail_payment_for_incorrect_cvc() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_cvc: Secret::new("12345".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Your card's security code is invalid.".to_string(),
+    );
+}
+
+// Creates a payment with incorrect expiry month.
+#[actix_web::test]
+async fn should_fail_payment_for_invalid_exp_month() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_exp_month: Secret::new("20".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Your card's expiration month is invalid.".to_string(),
+    );
+}
+
+// Creates a payment with incorrect expiry year.
+#[actix_web::test]
+async fn should_fail_payment_for_incorrect_expiry_year() {
+    let response = CONNECTOR
+        .make_payment(
+            Some(types::PaymentsAuthorizeData {
+                payment_method_data: types::api::PaymentMethod::Card(api::Card {
+                    card_exp_year: Secret::new("2000".to_string()),
+                    ..utils::CCardType::default().0
+                }),
+                ..utils::PaymentAuthorizeType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Your card's expiration year is invalid.".to_string(),
+    );
+}
+
+// Voids a payment using automatic capture flow (Non 3DS).
+#[actix_web::test]
+async fn should_fail_void_payment_for_auto_capture() {
+    let authorize_response = CONNECTOR.make_payment(None, None).await.unwrap();
+    assert_eq!(authorize_response.status, enums::AttemptStatus::Charged);
+    let txn_id = utils::get_connector_transaction_id(authorize_response.response);
+    assert_ne!(txn_id, None, "Empty connector transaction id");
+    let void_response = CONNECTOR
+        .void_payment(txn_id.unwrap(), None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        void_response.response.unwrap_err().message,
+        "You cannot cancel this PaymentIntent because it has a status of succeeded."
+    );
+}
+
+// Captures a payment using invalid connector payment id.
+#[actix_web::test]
+async fn should_fail_capture_for_invalid_payment() {
+    let capture_response = CONNECTOR
+        .capture_payment("123456789".to_string(), None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        capture_response.response.unwrap_err().message,
+        String::from("No such payment_intent: '123456789'")
+    );
+}
+
+// Refunds a payment with refund amount higher than payment amount.
+#[actix_web::test]
+async fn should_fail_for_refund_amount_higher_than_payment_amount() {
+    let response = CONNECTOR
+        .make_payment_and_refund(
+            None,
+            Some(types::RefundsData {
+                refund_amount: 150,
+                ..utils::PaymentRefundType::default().0
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.response.unwrap_err().message,
+        "Refund amount (₹1.50) is greater than charge amount (₹1.00)",
+    );
+}
+
+// Connector dependent test cases goes here
+
+// [#478]: add unit tests for non 3DS, wallets & webhooks in connector tests

--- a/crates/router/tests/connectors/connector_auth.rs
+++ b/crates/router/tests/connectors/connector_auth.rs
@@ -23,7 +23,7 @@ impl ConnectorAuthentication {
     pub(crate) fn new() -> Self {
         #[allow(clippy::expect_used)]
         toml::from_str(
-            &std::fs::read_to_string("tests/connectors/auth.toml")
+            &std::fs::read_to_string("tests/connectors/sample_auth.toml")
                 .expect("connector authentication config file not found"),
         )
         .expect("Failed to read connector authentication config file")

--- a/crates/router/tests/connectors/connector_auth.rs
+++ b/crates/router/tests/connectors/connector_auth.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 pub(crate) struct ConnectorAuthentication {
+	pub bambora: Option<HeaderKey>,
     pub aci: Option<BodyKey>,
     pub adyen: Option<BodyKey>,
     pub authorizedotnet: Option<BodyKey>,

--- a/crates/router/tests/connectors/main.rs
+++ b/crates/router/tests/connectors/main.rs
@@ -12,6 +12,7 @@ mod payu;
 mod rapyd;
 mod shift4;
 mod stripe;
+mod bambora;
 mod utils;
 mod worldline;
 mod worldpay;

--- a/crates/router/tests/connectors/sample_auth.toml
+++ b/crates/router/tests/connectors/sample_auth.toml
@@ -48,3 +48,6 @@ api_secret = "MySecretKey"
 key1 = "Merchant Id"
 api_key = "API Key"
 api_secret = "API Secret Key"
+
+[bambora]
+api_key = "MzAwMjEzMTkzOkQwMDIwODkyRjViMjQxZUVhMGIxODA1Rjk5NjgyMGU1"

--- a/crates/router/tests/connectors/utils.rs
+++ b/crates/router/tests/connectors/utils.rs
@@ -444,11 +444,11 @@ pub struct BrowserInfoType(pub types::BrowserInformation);
 impl Default for CCardType {
     fn default() -> Self {
         Self(api::Card {
-            card_number: Secret::new("4200000000000000".to_string()),
-            card_exp_month: Secret::new("10".to_string()),
-            card_exp_year: Secret::new("2025".to_string()),
+            card_number: Secret::new("4030000010001234".to_string()),
+            card_exp_month: Secret::new("02".to_string()),
+            card_exp_year: Secret::new("14".to_string()),
             card_holder_name: Secret::new("John Doe".to_string()),
-            card_cvc: Secret::new("999".to_string()),
+            card_cvc: Secret::new("123".to_string()),
         })
     }
 }

--- a/loadtest/config/Development.toml
+++ b/loadtest/config/Development.toml
@@ -84,6 +84,9 @@ base_url = "https://apple-pay-gateway.apple.com/"
 [connectors.klarna]
 base_url = "https://api-na.playground.klarna.com/"
 
+[connectors.bambora]
+base_url = 
+
 [connectors.supported]
 wallets = ["klarna", "braintree", "applepay"]
-cards = ["stripe", "adyen", "authorizedotnet", "checkout", "braintree", "cybersource", "shift4", "worldpay", "globalpay"]
+cards = ["stripe", "adyen", "authorizedotnet", "checkout", "braintree", "cybersource", "shift4", "worldpay", "globalpay", "bambora"]


### PR DESCRIPTION
Auth Capture and Void does not work properly for this connector we can Void or Refund and complete succeeded payment . But according to hyperswitch logic the payment should only be in authorized state to mark it as Void or to Capture it . 

Even if do a pre-auth we can mark it as void it can only be marked as completed and then refunded . 